### PR TITLE
Support parsing of TriG and N-Quads

### DIFF
--- a/lib/ParserStream.js
+++ b/lib/ParserStream.js
@@ -50,7 +50,8 @@ class ParserStream extends Readable {
       this.push(factory.quad(
         term(factory, rawQuad.subject, blankNodes),
         term(factory, rawQuad.predicate, blankNodes),
-        term(factory, rawQuad.object, blankNodes)
+        term(factory, rawQuad.object, blankNodes),
+        term(factory, rawQuad.graph, blankNodes)
       ))
     })
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/rdf-ext/rdf-parser-n3",
   "dependencies": {
-    "n3": "^0.9.1",
+    "n3": "^0.11.2",
     "rdf-data-model": "^1.0.0",
     "rdf-sink": "^1.0.0",
     "readable-stream": "^2.2.9"

--- a/test/test.js
+++ b/test/test.js
@@ -8,8 +8,9 @@ const N3Parser = require('..')
 
 describe('N3 parser', () => {
   const simpleNTGraph = '<http://example.org/subject> <http://example.org/predicate> "object".'
+  const simpleNQGraph = '<http://example.org/subject> <http://example.org/predicate> "object" <http://example.org/graph>.'
 
-  it('.import should parse the given string stream', (done) => {
+  it('.import should parse the given string triple stream', (done) => {
     let parser = new N3Parser()
     let counter = 0
 
@@ -18,6 +19,23 @@ describe('N3 parser', () => {
     }).on('end', () => {
       if (counter !== 1) {
         done('no triple streamed')
+      } else {
+        done()
+      }
+    }).on('error', (error) => {
+      done(error)
+    })
+  })
+
+  it('.import should parse the given string quad stream', (done) => {
+    let parser = new N3Parser()
+    let counter = 0
+
+    parser.import(stringToStream(simpleNQGraph)).on('data', () => {
+      counter++
+    }).on('end', () => {
+      if (counter !== 1) {
+        done('no quad streamed')
       } else {
         done()
       }


### PR DESCRIPTION
N3.js supports parsing of RDF quad serializations, such as TriG and N-Quads.
This PR makes sure that the parsed graph is taken into account.