### PR TITLE
Use N3.js factory

### DIFF
--- a/lib/ParserStream.js
+++ b/lib/ParserStream.js
@@ -2,18 +2,6 @@ const rdf = require('rdf-data-model')
 const Readable = require('readable-stream')
 const N3 = require('n3')
 
-function term (factory, rawNode) {
-  if (rawNode.termType === 'NamedNode') {
-    return factory.namedNode(rawNode.value)
-  } else if (rawNode.termType === 'BlankNode') {
-    return factory.blankNode(rawNode.value)
-  } else if (rawNode.termType === 'Literal') {
-    return factory.literal(rawNode.value, rawNode.language || rawNode.datatype)
-  } else if (rawNode.termType === 'DefaultGraph') {
-    return factory.defaultGraph()
-  }
-}
-
 class ParserStream extends Readable {
   constructor (input, options) {
     super({
@@ -29,27 +17,13 @@ class ParserStream extends Readable {
     const baseIRI = options.baseIRI || ''
     const factory = options.factory || rdf
 
-    input.on('error', (err) => {
-      this.emit('error', err)
-    })
+    const parser = new N3.Parser({baseIRI, factory})
 
-    const parser = new N3.Parser({documentIRI: baseIRI})
-
-    parser.parse(input, (err, rawQuad, rawPrefixes) => {
+    parser.parse(input, (err, quad) => {
       if (err) {
         return this.emit('error', err)
       }
-
-      if (!rawQuad) {
-        return this.push(null)
-      }
-
-      this.push(factory.quad(
-        term(factory, rawQuad.subject),
-        term(factory, rawQuad.predicate),
-        term(factory, rawQuad.object),
-        term(factory, rawQuad.graph)
-      ))
+      this.push(quad || null)
     })
   }
 


### PR DESCRIPTION
The latest N3.js develop now supports a `factory` constructor argument on the parser.

I've migrated the code and it works, except for the seemingly magical `importPrefixMap` option (which does not reoccur, but does seem to have an influence on the factory).